### PR TITLE
Update to ubuntu 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,26 @@ MAINTAINER Doug Goldstein <doug.goldstein@starlab.io>
 ENV DEBIAN_FRONTEND=noninteractive
 ENV USER root
 
-# build depends
+# build depends. Please keep the package list sorted
 RUN apt-get update && \
     apt-get --quiet --yes install \
-        build-essential pkg-config ca-certificates curl wget git libssl-dev \
-        software-properties-common gcc-multilib python2.7-dev bc \
-        python-pip python-virtualenv check linux-headers-generic \
-        apt-transport-https && \
-        apt-get autoremove -y && \
+        apt-transport-https \
+        bc \
+        build-essential \
+        ca-certificates \
+        check \
+        curl \
+        gcc-multilib \
+        git \
+        libssl-dev \
+        linux-headers-generic \
+        pkg-config \
+        python2.7-dev \
+        python-pip \
+        python-virtualenv \
+        software-properties-common \
+        wget \
+    &&  apt-get autoremove -y && \
         apt-get clean && \
         rm -rf /var/lib/apt/lists* /tmp/* /var/tmp/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM ubuntu:19.10
-MAINTAINER Doug Goldstein <doug.goldstein@starlab.io>
+FROM ubuntu:20.04
+MAINTAINER Starlab <support@starlab.io>
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV USER root
@@ -19,13 +19,14 @@ RUN apt-get update && \
         linux-headers-generic \
         pkg-config \
         python2.7-dev \
-        python-pip \
-        python-virtualenv \
+        python3-pip \
+        python3-virtualenv \
         software-properties-common \
         wget \
-    &&  apt-get autoremove -y && \
-        apt-get clean && \
-        rm -rf /var/lib/apt/lists* /tmp/* /var/tmp/*
+    &&  \
+    apt-get autoremove -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists* /tmp/* /var/tmp/*
 
 # Add the proxy cert (needs to come after ca-certificates installation)
 ADD proxy.crt /usr/local/share/ca-certificates/proxy.crt


### PR DESCRIPTION
The previous Ubuntu base image was based on 19.04, which is no longer supported (and apt commands were failing).